### PR TITLE
CICD Setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,13 @@
-FROM node:lts-alpine
-
-# install simple http server for serving static content
-RUN npm install -g http-server
-
-# make the 'app' folder the current working directory
+# build stage
+FROM node:lts-alpine as build-stage
 WORKDIR /app
-
-# copy both 'package.json' and 'package-lock.json' (if available)
 COPY package*.json ./
-
-# install project dependencies
-RUN npm install
-
-# copy project files and folders to the current working directory (i.e. 'app' folder)
+RUN npm install 
 COPY . .
-
-# build app for production with minification
 RUN npm run build
 
-EXPOSE 8080
-CMD [ "http-server", "dist" ]
+# production stage
+FROM nginx:stable-alpine as production-stage
+COPY --from=build-stage /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
       inputs: 
         artifactName: 'testImage'
         targetPath: './publish'
-  - job: a11y_test
+  - job: loading_image
     pool:
       vmImage: 'Ubuntu-16.04'
     dependsOn: build_image

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,12 +6,29 @@
 trigger:
 - master
 
-pool:
-  vmImage: 'Ubuntu-16.04'
 
 variables:
-  imageName: 'DevXAppHub:$(build.buildId)'
+  imageName: 'dxapphub:$(build.buildId)'
 
-steps:
-- script: docker build -f Dockerfile -t $(imageName) .
-  displayName: 'docker build'
+jobs: 
+  - job: build_image
+    pool:
+      vmImage: 'Ubuntu-16.04'
+    steps:
+    - script: docker build -f Dockerfile -t $(imageName) .
+      displayName: 'docker build'
+    - script: mkdir "publish" && docker save $(imageName) > ./publish/$(imageName.tar)
+      displayName: 'save docker image'
+    - task: PublishPipelineArtifact@0
+      inputs: 
+        artifactName: 'testImage'
+        targetPath: './publish'
+  - job: a11y_test
+    pool:
+      vmImage: 'Ubuntu-16.04'
+    steps:
+      - task: DownloadPipelineArtifact@0
+        inputs: 
+          targetPath: .
+          artifactName: 'testImage'
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - script: docker build -f Dockerfile -t $(imageName) .
       displayName: 'docker build'
-    - script: mkdir "publish" && docker save $(imageName) > ./publish/$(imageName.tar)
+    - script: mkdir "publish" && docker save $(imageName) > ./publish/$(imageName).tar
       displayName: 'save docker image'
     - task: PublishPipelineArtifact@0
       inputs: 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,4 +32,5 @@ jobs:
         inputs: 
           targetPath: .
           artifactName: 'testImage'
-            
+      - script: docker load $(imageName).tar
+        displayName: 'Loading Docker Image'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,9 +26,10 @@ jobs:
   - job: a11y_test
     pool:
       vmImage: 'Ubuntu-16.04'
+    dependsOn: build_image
     steps:
       - task: DownloadPipelineArtifact@0
         inputs: 
           targetPath: .
           artifactName: 'testImage'
-
+            

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,5 +32,5 @@ jobs:
         inputs: 
           targetPath: .
           artifactName: 'testImage'
-      - script: docker load $(imageName).tar
+      - script: docker load < $(imageName).tar
         displayName: 'Loading Docker Image'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@types/jest": "^23.1.4",
     "@vue/cli-plugin-babel": "^3.5.0",
-    "@vue/cli-plugin-e2e-cypress": "^3.5.0",
     "@vue/cli-plugin-eslint": "^3.5.0",
     "@vue/cli-plugin-pwa": "^3.5.0",
     "@vue/cli-plugin-typescript": "^3.5.0",


### PR DESCRIPTION
Optimize the Dockerfile so it's now a multistage build, this results in a smaller image to be passed between the various jobs in the pipeline. 

Adding a second job to test saving and loading the docker image in the pipeline, this test is not going to stick around too long. 

Removed the cypress plugin from VueJs which should result in a faster build time, we'll probably want to add this back in when we are doing E2E tests, although I was thinking of running those in another container so maybe we won't want to. 